### PR TITLE
Remove formula header from HTML

### DIFF
--- a/teste.html
+++ b/teste.html
@@ -394,9 +394,6 @@
                 <div class="gradient-border-content p-8">
                     <h2 class="text-2xl font-semibold mb-6 gradient-text section-title">Parâmetros de Cálculo</h2>
                     
-                    <div class="formula-box mb-6">
-                        <p class="formula-text">Valor Líquido = Valor Bruto × ((1 - ICMS) × (1 - PIS))</p>
-                    </div>
                     
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-8">
                         <div>


### PR DESCRIPTION
## Summary
- remove the header line "Fórmula utilizada para cálculo do valor líquido" from `teste.html`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`
- `cargo test` *(fails: could not find `Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_6853060f5438832b9959c819c5890683